### PR TITLE
Fix: checks for Redmine version 4.0

### DIFF
--- a/app/views/issues/_attributes.html.erb
+++ b/app/views/issues/_attributes.html.erb
@@ -1,4 +1,4 @@
-<% if Redmine::VERSION.to_s.starts_with?('3.3') || Redmine::VERSION.to_s.starts_with?('3.4') %>
+<% if Redmine::VERSION.to_s.starts_with?('3.3') || Redmine::VERSION.to_s.starts_with?('3.4') || Redmine::VERSION.to_s.starts_with?('4.0') %>
 
 <%= labelled_fields_for :issue, @issue do |f| %>
 

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,4 +1,4 @@
-<% if Redmine::VERSION.to_s.starts_with?('3.2') || Redmine::VERSION.to_s.starts_with?('3.3') || Redmine::VERSION.to_s.starts_with?('3.4') %>
+<% if Redmine::VERSION.to_s.starts_with?('3.2') || Redmine::VERSION.to_s.starts_with?('3.3') || Redmine::VERSION.to_s.starts_with?('3.4') || Redmine::VERSION.to_s.starts_with?('4.0') %>
 
 <%= render :partial => 'action_menu' %>
 
@@ -80,7 +80,7 @@
     end
   end
 end %>
-<% if Redmine::VERSION.to_s.starts_with?('3.4') %>
+<% if Redmine::VERSION.to_s.starts_with?('3.4') || Redmine::VERSION.to_s.starts_with?('4.0') %>
   <%= render_half_width_custom_fields_rows(@issue) %>
 <% else %>
   <%= render_custom_fields_rows(@issue) %>
@@ -175,7 +175,7 @@ end %>
     <%= auto_discovery_link_tag(:atom, {:format => 'atom', :key => User.current.rss_key}, :title => "#{@issue.project} - #{@issue.tracker} ##{@issue.id}: #{@issue.subject}") %>
 <% end %>
 
-<% if Redmine::VERSION.to_s.starts_with?('3.4') %>
+<% if Redmine::VERSION.to_s.starts_with?('3.4') || Redmine::VERSION.to_s.starts_with?('4.0') %>
   <%= context_menu %>
 <% else %>
   <%= context_menu issues_context_menu_path %>
@@ -260,7 +260,7 @@ end %>
     rows.right l(:label_spent_time), (@issue.total_spent_hours > 0 ? link_to(l_hours(@issue.total_spent_hours), issue_time_entries_path(@issue)) : "-"), :class => 'spent-time'
   end
 end %>
-<% if Redmine::VERSION.to_s.starts_with?('3.4') %>
+<% if Redmine::VERSION.to_s.starts_with?('3.4') || Redmine::VERSION.to_s.starts_with?('4.0') %>
   <%= render_half_width_custom_fields_rows(@issue) %>
 <% else %>
   <%= render_custom_fields_rows(@issue) %>
@@ -355,7 +355,7 @@ end %>
     <%= auto_discovery_link_tag(:atom, {:format => 'atom', :key => User.current.rss_key}, :title => "#{@issue.project} - #{@issue.tracker} ##{@issue.id}: #{@issue.subject}") %>
 <% end %>
 
-<% if Redmine::VERSION.to_s.starts_with?('3.4') %>
+<% if Redmine::VERSION.to_s.starts_with?('3.4') || Redmine::VERSION.to_s.starts_with?('4.0') %>
   <%= context_menu %>
 <% else %>
   <%= context_menu issues_context_menu_path %>


### PR DESCRIPTION
Since [Redmine 4.0](https://www.redmine.org/versions/99) was released December 2018, it is reasonable to introduce additional conditions adapting HTML-rendering for recent version of Rails to avoid the following errors:
```
ActionView::Template::Error (undefined method `render_custom_fields_rows' for #<#<Class:0x0000560fbf24c8c0>:0x0000560fbf2526a8>
Did you mean?  render_custom_fields_tabs
               render_custom_field_values):
    263: <% if Redmine::VERSION.to_s.starts_with?('3.4') %>
    264:   <%= render_half_width_custom_fields_rows(@issue) %>
    265: <% else %>
    266:   <%= render_custom_fields_rows(@issue) %>
    267: <% end %>
    268: <%= call_hook(:view_issues_show_details_bottom, :issue => @issue) %>
    269: </table>
  
plugins/mega_calendar/app/views/issues/show.html.erb:266:in `_plugins_mega_calendar_app_views_issues_show_html_erb___3635081213966266842_47312815687500'
app/controllers/issues_controller.rb:107:in `block (2 levels) in show'
app/controllers/issues_controller.rb:100:in `show'
lib/redmine/sudo_mode.rb:63:in `sudo_mode'
  Rendering plugins/mega_calendar/app/views/issues/show.html.erb within layouts/base
  Rendered issues/_action_menu.html.erb (18.6ms)
  Rendered plugins/mega_calendar/app/views/issues/show.html.erb within layouts/base (300.5ms)
Completed 500 Internal Server Error in 599ms (ActiveRecord: 136.6ms)
```
and
```
ActionView::Template::Error (wrong number of arguments (given 1, expected 0)):
    358: <% if Redmine::VERSION.to_s.starts_with?('3.4') %>
    359:   <%= context_menu %>
    360: <% else %>
    361:   <%= context_menu issues_context_menu_path %>
    362: <% end %>
    363: 
    364: <% end %>
  
app/helpers/application_helper.rb:1354:in `context_menu'
plugins/mega_calendar/app/views/issues/show.html.erb:361:in `_plugins_mega_calendar_app_views_issues_show_html_erb___277084332184107449_47368452541140'
app/controllers/issues_controller.rb:107:in `block (2 levels) in show'
app/controllers/issues_controller.rb:100:in `show'
lib/redmine/sudo_mode.rb:63:in `sudo_mode'
  Rendered issue_relations/_form.html.erb (13.8ms)
  Rendered issues/_relations.html.erb (73.1ms)
  Rendered issues/_history.html.erb (120.8ms)
  Rendered issues/_action_menu.html.erb (17.7ms)
  Rendered issues/_form_custom_fields.html.erb (2.4ms)
  Rendered plugins/mega_calendar/app/views/issues/_attributes.html.erb (177.5ms)
  Rendered plugins/mega_calendar/app/views/issues/_form.html.erb (264.5ms)
  Rendered attachments/_form.html.erb (22.4ms)
  Rendered issues/_edit.html.erb (442.9ms)
  Rendered issues/_sidebar.html.erb (14.9ms)
  Rendered watchers/_watchers.html.erb (41.8ms)
  Rendered plugins/mega_calendar/app/views/issues/show.html.erb within layouts/base (1051.7ms)
Completed 500 Internal Server Error in 1739ms (ActiveRecord: 359.0ms)
```
In the rest **[the plugin works fine for Redmine 4.0.0](https://github.com/berti92/mega_calendar/commit/d54e56acbcfe814a42bf25c76d6854a9d986389a)** and the branch [can be merged](https://github.com/berti92/mega_calendar/issues/79#issuecomment-447669597) to master.