### PR TITLE
Improving query speed

### DIFF
--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -198,8 +198,8 @@ class CalendarController < ApplicationController
     if fuser.blank?
       holidays = Holiday.where(['((holidays.start <= ? AND holidays.'+( ActiveRecord::Base.connection.adapter_name.downcase == 'sqlserver' ? '[end]' : 'end' )+' >= ?) OR (holidays.start BETWEEN ? AND ?)  OR (holidays.'+( ActiveRecord::Base.connection.adapter_name.downcase == 'sqlserver' ? '[end]' : 'end' )+' BETWEEN ? AND ?))',fbegin.to_s,fend.to_s,fbegin.to_s,fend.to_s,fbegin.to_s,fend.to_s]).where(holidays_condition) rescue []
       issues = Issue.where(['((issues.start_date <= ? AND issues.due_date >= ?) OR (issues.start_date BETWEEN ? AND ?)  OR (issues.due_date BETWEEN ? AND ?))',fbegin.to_s,fend.to_s,fbegin.to_s,fend.to_s,fbegin.to_s,fend.to_s]).where(issues_condition) rescue []
-      issues2 = Issue.where(['issues.start_date >= ? AND issues.due_date IS NULL',fbegin.to_s]).where(issues_condition) rescue []
-      issues3 = Issue.where(['issues.start_date IS NULL AND issues.due_date <= ?',fend.to_s]).where(issues_condition) rescue []
+      issues2 = Issue.where(['issues.start_date >= ? AND issues.start_date <= ? AND issues.due_date IS NULL',fbegin.to_s,fend.to_s]).where(issues_condition) rescue []
+      issues3 = Issue.where(['issues.start_date IS NULL AND issues.due_date <= ? AND issues.due_date >= ?',fend.to_s,fbegin.to_s]).where(issues_condition) rescue []
       if Setting.plugin_mega_calendar['display_empty_dates'].to_i == 1
         issues4 = Issue.where(['issues.start_date IS NULL AND issues.due_date IS NULL AND (issues.created_on BETWEEN ? AND ?)',fbegin.to_s,fend.to_s]).where(issues_condition) rescue []
       else
@@ -210,8 +210,8 @@ class CalendarController < ApplicationController
       cur_user_ids += User.current.groups.collect{|x| x.id} rescue []
       holidays = Holiday.where(['((holidays.start <= ? AND holidays.'+( ActiveRecord::Base.connection.adapter_name.downcase == 'sqlserver' ? '[end]' : 'end' )+' >= ?) OR (holidays.start BETWEEN ? AND ?)  OR (holidays.'+( ActiveRecord::Base.connection.adapter_name.downcase == 'sqlserver' ? '[end]' : 'end' )+' BETWEEN ? AND ?)) AND (holidays.user_id = ? OR holidays.user_id IS NULL)',fbegin.to_s,fend.to_s,fbegin.to_s,fend.to_s,fbegin.to_s,fend.to_s,User.current.id]).where(holidays_condition) rescue []
       issues = Issue.where(['((issues.start_date <= ? AND issues.due_date >= ?) OR (issues.start_date BETWEEN ? AND ?)  OR (issues.due_date BETWEEN ? AND ?)) AND issues.assigned_to_id IN (?)',fbegin.to_s,fend.to_s,fbegin.to_s,fend.to_s,fbegin.to_s,fend.to_s,cur_user_ids]).where(issues_condition) rescue []
-      issues2 = Issue.where(['issues.start_date >= ? AND issues.due_date IS NULL AND issues.assigned_to_id IN (?)',fbegin.to_s,cur_user_ids]).where(issues_condition) rescue []
-      issues3 = Issue.where(['issues.start_date IS NULL AND issues.due_date <= ? AND issues.assigned_to_id IN (?)',fend.to_s,cur_user_ids]).where(issues_condition) rescue []
+      issues2 = Issue.where(['issues.start_date >= ? AND issues.start_date <= ? AND issues.due_date IS NULL AND issues.assigned_to_id IN (?)',fbegin.to_s,fend.to_s,cur_user_ids]).where(issues_condition) rescue []
+      issues3 = Issue.where(['issues.start_date IS NULL AND issues.due_date <= ? AND issues.due_date >= ? AND issues.assigned_to_id IN (?)',fend.to_s,fbegin.to_s,cur_user_ids]).where(issues_condition).where(issues_condition) rescue []
       issues4 = Issue.where(['issues.start_date IS NULL AND issues.due_date IS NULL AND issues.assigned_to_id IN (?)',cur_user_ids]).where(issues_condition) rescue []
     end
     if Setting.plugin_mega_calendar['display_empty_dates'].to_i == 1


### PR DESCRIPTION
Adding conditions in order to not query entries that end before the calendar we are viewing (in the case of those without start dates), or start after the calendar that we are viewing  (in the case of those that don't have due dates).
This improves the query time by a lot.
In my case, on version 1.9.9 going from 59sec to an average of 5.5sec.
And compared to the version 1.7.1 which was at 18sec.
