### PR TITLE
Remove login requirement for export

### DIFF
--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -1,7 +1,8 @@
 class CalendarController < ApplicationController
   unloadable
 
-  before_action(:check_plugin_right)
+  before_action :check_plugin_right
+  before_action :check_if_login_required, except:[:export]
 
   def check_plugin_right
     user_id_of_api_key = '-1'


### PR DESCRIPTION
Inherited check_if_login_required denied export with only API key authentication and force redirected to login.
This was making it unusable for web calendar import in M365 Exchange, Google calendar etc.