### PR TITLE
feat: persist view, date, issue filter, and calendar filters using localStorage

### DIFF
--- a/app/views/calendar/_filter_panel.html.erb
+++ b/app/views/calendar/_filter_panel.html.erb
@@ -38,7 +38,7 @@
       </tr>
     <% end %>
     </table>
-    <a href="#" class="icon icon-checked" onclick="window.calendar.refetchEvents();"><%= translate 'button_apply' %></a> &nbsp; <a href="#" class="icon icon-reload" onclick="reset_and_reload_filters();"><%= translate 'button_reset' %></a>
+    <a href="#" class="icon icon-checked" onclick="save_filter_to_localStorage();window.calendar.refetchEvents();"><%= translate 'button_apply' %></a> &nbsp; <a href="#" class="icon icon-reload" onclick="reset_and_reload_filters();"><%= translate 'button_reset' %></a>
     <div>
       <hr>
       <table>
@@ -99,5 +99,24 @@
       $("#inp_filter_global").prop('checked', data["global"]);
       calendar.refetchEvents();
     });
+  }
+  function save_filter_to_localStorage() {
+    const filterData = $('#calendar_filter').serializeObject()["filter"];
+    localStorage.setItem("mega_calendar_filter", JSON.stringify(filterData));
+  }
+  function load_filter_from_localStorage() {
+    const filterStr = localStorage.getItem("mega_calendar_filter");
+    if (!filterStr) return;
+    try {
+      const filter = JSON.parse(filterStr);
+      Object.keys(filter).forEach(function(key) {
+        $("#filter_id_" + key + "_enabled").prop('checked', (filter[key]["enabled"] === "true" || filter[key]["enabled"] === true));
+        $("#filter_id_" + key + "_value").val(filter[key]["value"]);
+        $("#filter_id_" + key + "_operator").val(filter[key]["operator"]);
+      });
+      calendar.refetchEvents();
+    } catch (e) {
+      console.error("Failed to parse filter from localStorage", e);
+    }
   }
 </script>

--- a/app/views/calendar/_megacalendar.html.erb
+++ b/app/views/calendar/_megacalendar.html.erb
@@ -33,7 +33,11 @@
 %>
 
 <script type="text/javascript">
-  var user_query = <%= js_user_query.to_s %>;
+  var user_query = (function() {
+    const saved = localStorage.getItem("mega_calendar_user_query");
+    return saved === null ? <%= js_user_query.to_s %> : (saved === "true");
+  })();
+
   function set_active_button(user) {
     var btn_mytickets = $('.fc-myTickets-button');
     var btn_alltickets = $('.fc-allTickets-button');
@@ -49,7 +53,8 @@
     var calendarEl = document.getElementById('mega_calendar__calendar');
 
     window.calendar = new FullCalendar.Calendar(calendarEl, {
-      initialView: '<%= default_view %>',
+      initialView: localStorage.getItem("mega_calendar_view") || '<%= default_view %>',
+      initialDate: localStorage.getItem("mega_calendar_current_date") || '<%= js_default_date %>',
       locale: '<%= js_locale %>',
       selectable: true,
       editable: true,
@@ -65,6 +70,7 @@
           text: '<%= translate 'my_issues' %>',
           click: function() {
             user_query = true;
+            localStorage.setItem("mega_calendar_user_query", "true");
             set_active_button(user_query);
             calendar.refetchEvents();
           }
@@ -73,6 +79,7 @@
           text: '<%= translate 'all_issues' %>',
           click: function() {
             user_query = false;
+            localStorage.setItem("mega_calendar_user_query", "false");
             set_active_button(user_query);
             calendar.refetchEvents();
           }
@@ -126,8 +133,16 @@
           $.get('<%= Setting.plugin_mega_calendar['sub_path'] %>calendar/change_' + info.event.extendedProps.controller_name, { id: info.event.id, event_begin: moment(event_begin).format("YYYY-MM-DD HH:mm"), event_end: moment(event_end).format("YYYY-MM-DD HH:mm"), allDay: allDay });
         }
       },
+      viewDidMount: function(view) {
+        localStorage.setItem("mega_calendar_view", view.view.type);
+      },
+      datesSet: function(info) {
+        const date = moment(info.view.currentStart).format("YYYY-MM-DD");
+        localStorage.setItem("mega_calendar_current_date", date);
+      },
     });
     calendar.render();
+    load_filter_from_localStorage();
     set_active_button(user_query);
   //   $('#mega_calendar__calendar').fullCalendar({
   //       lang: '<%= js_locale %>',


### PR DESCRIPTION
This PR enhances the user experience of the MegaCalendar by preserving the following UI states via localStorage:

- Selected view (month/week/day)
- Current displayed date
- Issue filter mode (My Issues / All Issues)
- Filter panel values

These values are automatically restored on page load to provide a seamless experience across sessions.
