### PR TITLE
feat: display ticket title in tooltip to prevent truncation

### DIFF
--- a/app/views/calendar/_megacalendar.html.erb
+++ b/app/views/calendar/_megacalendar.html.erb
@@ -98,11 +98,12 @@
         }
       ],
       eventDidMount: function(info) {
-        info.el.title = info.event.extendedProps.description;
+        const title = info.event.title;
+        const desc = info.event.extendedProps.description || "";
+        const fullTooltip = `<strong>${title}</strong><br>${desc}`;
+        info.el.title = `${title} - ${desc}`;
         $(info.el).tooltip({
-          content: function () {
-            return $(this).prop('title');
-          }
+          content: fullTooltip
         });
       },
       select: function(info) {


### PR DESCRIPTION
## Summary

This PR enhances the calendar tooltips by displaying the ticket title in addition to the description.

## Motivation

Ticket titles are often truncated in the calendar view due to limited space.  
By showing the full title in the tooltip, users can easily confirm the issue without needing to click.

## Implementation

- `eventDidMount` updated to show both `event.title` and `event.extendedProps.description` in the tooltip
- Tooltip content is now formatted as HTML with the title in bold

## Before

Only the issue description was shown in the tooltip.

## After

Tooltip includes both:
- **Ticket title** (bold)
- Description (if available)
