### PR TITLE
Fix empty assignee dropdown when displayed_users contains group IDs

### DIFF
--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -12,7 +12,7 @@ class Holiday < ActiveRecord::Base
   end
 
   def self.get_activated_users
-    return User.where(["users.id IN (?) AND users.login IS NOT NULL AND users.login <> ''",Setting.plugin_mega_calendar['displayed_users']]).order("users.login ASC")
+    return User.where(["(users.id IN (?) OR users.id IN (SELECT user_id FROM groups_users WHERE group_id IN (?))) AND users.login IS NOT NULL AND users.login <> ''",Setting.plugin_mega_calendar['displayed_users'],Setting.plugin_mega_calendar['displayed_users']]).order("users.login ASC")
   end
 
   def self.get_activated_groups


### PR DESCRIPTION
Fixes #138

## Summary

The assignee dropdown in the calendar filter panel is empty when `displayed_users` contains group IDs, even though the calendar correctly displays issues for members of those groups.

The query used to populate the calendar (`query_filter` in `calendar_controller.rb` line 42) already handles both cases: it accepts both user IDs and group IDs in `displayed_users` via `OR users.id IN (SELECT user_id FROM groups_users WHERE group_id IN (?))`.

This PR applies the **exact same logic** to `Holiday.get_activated_users` so the dropdown is populated with the actual users that can be assigned in the calendar.

## Changes

- `app/models/holiday.rb`: 1 line changed
- No new configuration variable
- No new dependencies
- No translation files touched

## Test plan

1. Set `displayed_users` to a list of group IDs in the plugin settings.
2. Open the calendar — issues from group members are visible (already works).
3. Open the filter panel — the `Assigner à` dropdown is now populated with users that are members of those groups.
4. Pick an assignee — only their issues remain visible.

Tested on Redmine 6.1.2 + MySQL 8.0.45 with a `displayed_users` setting containing 10 IDs (mix of group IDs and user IDs, `displayed_type = "groups_and_users"`). Dropdown populated with 43 users (all members of the configured groups), filter applies correctly.

Made with [Cursor](https://cursor.com)