### PR TITLE
Fix missing Save button on user edit form in Redmine 6.1+

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -41,6 +41,14 @@
   <p><%= f.check_box :must_change_passwd %></p>
   </div>
 </fieldset>
+<p class="mobile-hide">
+  <% if @user.new_record? %>
+    <%= submit_tag l(:button_create) %>
+    <%= submit_tag l(:button_create_and_continue), :name => 'continue' %>
+  <% else %>
+    <%= submit_tag l(:button_save) %>
+  <% end %>
+</p>
 </div>
 
 <div class="splitcontentright">


### PR DESCRIPTION
Fix missing Save button on user edit form in Redmine 6.1+

Restore the mobile-hide submit block in users/_form.html.erb.

Fixes berti92/mega_calendar#140